### PR TITLE
Changes

### DIFF
--- a/overrides/config/bloodmagic/bloodmagic.cfg
+++ b/overrides/config/bloodmagic/bloodmagic.cfg
@@ -84,7 +84,7 @@ general {
     B:enableDebugLogging=false
 
     # Enables tier 6 related registrations. This is for pack makers.
-    B:enableTierSixEvenThoughThereIsNoContent=false
+    B:enableTierSixEvenThoughThereIsNoContent=true
 
     # Enables extra information to be printed to the log.
     # Warning: May drastically increase log size.

--- a/overrides/config/modularmachinery/recipes/corrupted_starlight.json
+++ b/overrides/config/modularmachinery/recipes/corrupted_starlight.json
@@ -35,26 +35,26 @@
         {
             "type": "item",
             "io-type": "input",
-            "item": "bloodmagic:demon_crystal@4",
-            "amount": 1
+            "item": "bloodmagic:item_demon_crystal@4",
+            "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "bloodmagic:demon_crystal@3",
-            "amount": 1
+            "item": "bloodmagic:item_demon_crystal@3",
+            "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "bloodmagic:demon_crystal@2",
-            "amount": 1
+            "item": "bloodmagic:item_demon_crystal@2",
+            "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "bloodmagic:demon_crystal@1",
-            "amount": 1
+            "item": "bloodmagic:item_demon_crystal@1",
+            "amount": 4
         }
     ]
 }

--- a/overrides/scripts/mods/bloodmagic.zs
+++ b/overrides/scripts/mods/bloodmagic.zs
@@ -27,12 +27,24 @@ recipes.addShaped(<bloodmagic:incense_altar>, [
     [<ore:plankWood>, <bloodmagic:slate:1>, <ore:plankWood>]
 ]);
 
+// Crystal Cluster Bricks
+recipes.addShaped(<bloodmagic:decorative_brick:3> *4, [
+    [<bloodmagic:decorative_brick:2>, <bloodmagic:decorative_brick:2>],
+    [<bloodmagic:decorative_brick:2>, <bloodmagic:decorative_brick:2>]
+]);
+
 
 ### BLOOD ALTAR ###
 
 // blank slate
 BloodAltar.removeRecipe(<minecraft:stone>);
 BloodAltar.addRecipe(<bloodmagic:slate>, <botania:livingrock:4>, 0, 1000, 25, 5);
+
+// Tier 6 Capstones | Crystal Cluster
+BloodAltar.addRecipe(<bloodmagic:decorative_brick:2>, <contenttweaker:corruptedstarmetal>, 4, 100000, 50, 10);
+
+// Schwarzschild's Sphere | ATM Tweaks
+BloodAltar.addRecipe(<atmtweaks:item_material:6>, <thaumcraft:voidseer_charm>, 5, 500000, 30, 10);
 
 // crystallized blood pile | ContentTweaker
 BloodAltar.addRecipe(<contenttweaker:crystallisedblood>, <botania:manaresource:8>, 3, 30000, 50, 10);

--- a/overrides/scripts/mods/botania.zs
+++ b/overrides/scripts/mods/botania.zs
@@ -407,12 +407,6 @@ RuneAltar.addRecipe(<bloodmagic:decorative_brick>, [
     <mekanism:polyethene>, <mekanism:polyethene>, <bloodmagic:blood_shard>
 ], 10000);
 
-// schwarzschilds sphere | ATM Tweaks
-RuneAltar.addRecipe(<atmtweaks:item_material:6>, [
-    <thaumcraft:voidseer_charm>, <thaumcraft:causality_collapser>, <botania:manaresource:14>,
-    <thaumcraft:ingot:1>, <draconicevolution:wyvern_core>
-], 25000);
-
 // certus quartz seeds | AgriCraft
 RuneAltar.addRecipe(<agricraft:agri_seed>.withTag({agri_analyzed: 0 as byte, agri_strength: 1 as byte, agri_gain: 1 as byte, agri_seed: "appliedenergistics2:certus_quartz_plant", agri_growth: 1 as byte}), [
     <minecraft:wheat_seeds>.withTag({agri_analyzed: 1 as byte, agri_strength: 10 as byte, agri_gain: 10 as byte, agri_seed: "vanilla:wheat_plant", agri_growth: 10 as byte}),

--- a/overrides/scripts/mods/logisticspipes.zs
+++ b/overrides/scripts/mods/logisticspipes.zs
@@ -1,10 +1,34 @@
 ##########################################################################################
 #modloaded logisticspipes
 #priority 100
+import mods.jei.JEI.removeAndHide as rh;
 
 print("==================== loading mods logisticspipes.zs ====================");
 ##########################################################################################
 
+
+### REMOVE ITEMS NOT IMPLEMENTED ###
+rh(<logisticspipes:parts>);
+rh(<logisticspipes:parts:1>);
+rh(<logisticspipes:parts:2>);
+rh(<logisticspipes:parts:3>);
+rh(<logisticspipes:hud_glasses>);
+rh(<logisticspipes:upgrade_logic_controller>);
+rh(<logisticspipes:power_provider_rf>);
+rh(<logisticspipes:power_provider_eu>);
+rh(<logisticspipes:power_provider_mj>);
+rh(<logisticspipes:upgrade_power_transportation>);
+rh(<logisticspipes:upgrade_power_supplier_rf>);
+rh(<logisticspipes:upgrade_power_supplier_eu_lv>);
+rh(<logisticspipes:upgrade_power_supplier_eu_mv>);
+rh(<logisticspipes:upgrade_power_supplier_eu_hv>);
+rh(<logisticspipes:upgrade_power_supplier_eu_ev>);
+rh(<logisticspipes:broken_item>);
+
+### TOOLTIPS ###
+<logisticspipes:crafting_table>.addTooltip("Used for autocrafting with Logistics");
+<logisticspipes:crafting_table_fuzzy>.addTooltip("Used for oredict autocrafting with Logistics");
+<logisticspipes:pipe_request_table>.addTooltip("This is your Logistics Crafting Terminal");
 
 ### CRAFTING RECIPES ###
 


### PR DESCRIPTION
Quests:
Tier 1: Rearranged quests with buckets to make it clear you need a blast furnace first
		Added more Logisticpipes quests to help people get started.
Tier 5: Rewritten Advanced Rocketry Quests to reflect the journey you have to complete
Tier 6: Added Tier 6 blood magic integration on the ATM Star

Recipie Changes:
Logistic Pipes: Hid some items from JEI that are not implemented in the mod yet
Blood Magic:	Enabled Tier 6 Crystal Cluster caps
				Added Schwarzschild's Sphere as a Tier 6 blood altar craft
Botania: 		Removed Schwarzschild's Sphere from altar craft

Config Changes:
bloodmagic/bloodmagic.cfg:	enabled tier 6 content
modularmachinery/recipes/corrupted_starlight.json: removed the need for will clusters and replaced with 4x of the corresponding will. This is to make the ingots being able to support autocraft.